### PR TITLE
Foo/coaching | Coaching management feature

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
@@ -5,12 +5,10 @@ class FundaWande_Coaching_Table extends WP_List_Table {
 
 	public function __construct( ) {
 
-		// parent::__construct( array(
-		// 	'singular' => 'course',
-		// 	'plural'   => 'courses',
-		// 	'ajax'     => false
-		// ) );
+		// Necessary to assign screen manually to avoid errors
 		$this->screen = get_current_screen();
+
+		// Assign the coaches the local variable for use  in table
 		$this->coaches = FundaWande()->coaching_utils->get_coaches();
 
 	}
@@ -106,12 +104,9 @@ class FundaWande_Coaching_Table extends WP_List_Table {
 	}
 
 	protected function get_sortable_columns() {
-		// return array(
-		// 	'course'         => [ 'display_name', false ],
-		// 	'status'       => [ 'status', false ],
-		// 	'start_date'   => [ 'start_date', false ],
-		// 	'last_updated' => [ 'last_updated', false ]
-		// );
+		return array(
+			'user'         => [ 'display_name', false ]
+		);
 	}
 
 	
@@ -161,7 +156,11 @@ class FundaWande_Coaching_Table extends WP_List_Table {
 			$course_id = (int) $_GET['course_id'];
             
 		}
-		$users = FundaWande()->coaching_utils->get_course_users($course_id);
+		// Order
+		$orderby = ! empty( $_GET["orderby"] ) ? esc_sql( $_GET["orderby"] ) : 'display_name';
+		$order   = ! empty( $_GET["order"] ) ? esc_sql( $_GET["order"] ) : 'ASC';
+	
+		$users = FundaWande()->coaching_utils->get_course_users($course_id,$orderby,$order);
 
 		// Columns
 		$columns               = $this->get_columns();

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
@@ -109,47 +109,6 @@ class FundaWande_Coaching_Table extends WP_List_Table {
 		);
 	}
 
-	
-
-	public function process_bulk_action() {
-		// $key         = $this->_args['singular'];
-		// $request_ids = isset( $_REQUEST[ $key ] ) ? wp_parse_id_list( wp_unslash( $_REQUEST[ $key ] ) ) : [];
-
-		// // Nothing selected?
-		// if ( ! count( $request_ids ) ) {
-		// 	return;
-		// }
-
-		// // Delete.
-		// if ( $this->current_action() === 'delete' ) {
-		// 	LMS()->courses_admin_utils->delete_courses( $request_ids );
-
-		// 	return;
-		// }
-
-		// // Set status.
-		// $status_prefix = 'set_status_to_';
-		// if ( substr( $this->current_action(), 0, strlen( $status_prefix ) ) === $status_prefix ) {
-		// 	$status = (int) substr( $this->current_action(), strlen( $status_prefix ) );
-		// 	AdvantageLearn()->cohorts->set_status_for_cohort_users( $request_ids, $this->cohort_id, $status );
-
-		// 	return;
-		// }
-	}
-
-	// protected function extra_tablenav( $which ) {
-	// 	if ( $which !== 'top' ) {
-	// 		return;
-	// 	}
-
-	// 	$query   = new WP_Query( [
-	// 		'post_type'      => 'cohorts',
-	// 		'posts_per_page' => - 1
-	// 	] );
-	// 	$cohorts = $query->get_posts();
-	// 
-	// }
-
 	public function prepare_items() {
 		
 		if ( isset( $_GET['course_id'] ) ) {

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-table.php
@@ -1,0 +1,203 @@
+<?php
+
+class FundaWande_Coaching_Table extends WP_List_Table {
+	public $coaches;
+
+	public function __construct( ) {
+
+		// parent::__construct( array(
+		// 	'singular' => 'course',
+		// 	'plural'   => 'courses',
+		// 	'ajax'     => false
+		// ) );
+		$this->screen = get_current_screen();
+		$this->coaches = FundaWande()->coaching_utils->get_coaches();
+
+	}
+
+	protected function column_cb( $item ) {
+		return sprintf(
+			'<input type="checkbox" class="_cb" name="user_select[%s]" value="%s">',
+			$item->ID,
+			$item->ID
+		);
+	}
+
+	protected function column_user( $item ) {
+		return sprintf(
+			'
+				<p>%s</p>
+				<div class="row-actions">
+					<span class="edit"><a href="%s">View user</a></span>
+				</div>
+			',
+			$item->display_name,
+			'/wp-admin/user-edit.php?user_id='.$item->ID
+		);
+	}
+
+	
+
+	protected function column_coach( $item ) {
+		$coaches = $this->coaches;
+		$data =  sprintf(
+			'<select id="coach_id" name="coaches[%s]" class="form-control  customSelect searchSelect" >
+			<option value="" selected disabled>Assign a coach</option>',
+			$item->ID
+
+		);
+
+		foreach ($coaches as $coach) { 
+			$selected = ($coach->ID == $item->coach) ? 'selected' : '';
+			$name = $coach->ID .' | '.$coach->display_name;
+			$data .= sprintf( '
+			 <option value="%s" %s>%s</option>',
+			 $coach->ID,
+			 $selected,
+			 $name
+			);
+		}
+		$data .= '</select>';
+
+		return $data;
+	}
+
+
+	public function get_columns() {
+		return array(
+			'cb'           => '<input type="checkbox" />',
+			'user'         => 'User',
+			'coach'  => 'Coach',
+		);
+	}
+
+	protected function extra_tablenav( $which ) {
+		if ( $which !== 'top' ) {
+			return;
+		}
+
+		$coaches = $this->coaches;
+		$data =  sprintf(
+			'<select id="bulk_coach_id" name="bulk_coach" class="form-control  customSelect searchSelect" >
+			<option value="all" selected disabled>Bulk assign a coach</option>'
+
+		);
+
+		foreach ($coaches as $coach) { 
+			$selected = '';
+			$name = $coach->ID .' | '.$coach->display_name;
+			$data .= sprintf( '
+			 <option value="%s" %s>%s</option>',
+			 $coach->ID,
+			 $selected,
+			 $name
+			);
+		}
+		$data .= '</select>';
+		?>
+		<div class="alignleft actions">
+			<label for="bulk_coach_id" class="screen-reader-text">Bulk add coach</label>
+			
+				<?php
+				echo $data;
+				?>
+			</div >
+		<?php
+	}
+
+	protected function get_sortable_columns() {
+		// return array(
+		// 	'course'         => [ 'display_name', false ],
+		// 	'status'       => [ 'status', false ],
+		// 	'start_date'   => [ 'start_date', false ],
+		// 	'last_updated' => [ 'last_updated', false ]
+		// );
+	}
+
+	
+
+	public function process_bulk_action() {
+		// $key         = $this->_args['singular'];
+		// $request_ids = isset( $_REQUEST[ $key ] ) ? wp_parse_id_list( wp_unslash( $_REQUEST[ $key ] ) ) : [];
+
+		// // Nothing selected?
+		// if ( ! count( $request_ids ) ) {
+		// 	return;
+		// }
+
+		// // Delete.
+		// if ( $this->current_action() === 'delete' ) {
+		// 	LMS()->courses_admin_utils->delete_courses( $request_ids );
+
+		// 	return;
+		// }
+
+		// // Set status.
+		// $status_prefix = 'set_status_to_';
+		// if ( substr( $this->current_action(), 0, strlen( $status_prefix ) ) === $status_prefix ) {
+		// 	$status = (int) substr( $this->current_action(), strlen( $status_prefix ) );
+		// 	AdvantageLearn()->cohorts->set_status_for_cohort_users( $request_ids, $this->cohort_id, $status );
+
+		// 	return;
+		// }
+	}
+
+	// protected function extra_tablenav( $which ) {
+	// 	if ( $which !== 'top' ) {
+	// 		return;
+	// 	}
+
+	// 	$query   = new WP_Query( [
+	// 		'post_type'      => 'cohorts',
+	// 		'posts_per_page' => - 1
+	// 	] );
+	// 	$cohorts = $query->get_posts();
+	// 
+	// }
+
+	public function prepare_items() {
+		
+		if ( isset( $_GET['course_id'] ) ) {
+			$course_id = (int) $_GET['course_id'];
+            
+		}
+		$users = FundaWande()->coaching_utils->get_course_users($course_id);
+
+		// Columns
+		$columns               = $this->get_columns();
+		$hidden                = array();
+		$sortable              = $this->get_sortable_columns();
+		$this->_column_headers = array( $columns, $hidden, $sortable );
+
+		// Process bulk actions.
+		$this->process_bulk_action();
+		// Fetch items.
+		$this->items = $users;
+	}
+
+	public function display() {
+		parent::display();
+
+		?>
+		<script>
+            jQuery(document).ready(function ($) {
+                $('a[data-action]').on('click', function () {
+                    // Deselect all other rows.
+                    $('#the-list input._cb').prop('checked', false);
+
+                    // Select this row.
+                    $(this).closest('tr').find('input._cb').prop('checked', true);
+
+                    // Set action.
+                    $('#bulk-action-selector-top').val($(this).attr('data-action'));
+
+                    // Submit form.
+                    $(this).closest('form').submit();
+
+                    return false;
+                });
+            });
+		</script>
+		<?php
+	}
+}

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
@@ -1,0 +1,83 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // security check, don't load file outside WP
+}
+
+
+/**
+ * FundaWande Coaching Utils Class
+ *
+ * All functionality pertaining to the coaching utils functionality of FundaWande.
+ *
+ * @package Core
+ * @author Pango
+ *
+ * @since 1.0.00
+ */
+class FundaWande_Coaching_Utils {
+
+
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+
+
+    }
+
+    
+
+    /**
+     * Get the course users and coaches.
+     *
+     * @param integer $course_id the ID of the course.
+     *
+     * @return array array of users in the course
+     */
+    public function get_course_users($course_id) {
+
+        $user_args = array(
+            'meta_query' => array(
+                array(
+                    'key' => 'fw_current_course',
+                    'value' => $course_id,
+                    'compare' => '=='
+                ),
+            )
+        );
+
+        $users = get_users( $user_args );
+        
+        foreach ($users as $key => $user) {
+            $user->coach = get_user_meta($user->ID,'fw_coach',true);
+        }
+
+        return $users;
+        
+
+    } // end get_course_users()
+
+    /**
+     * Get the coaches.
+     *
+     *
+     * @return array array of users in the course
+     */
+    public function get_coaches() {
+
+        $user_args = array(
+            
+        );
+
+        $users = get_users( $user_args );
+        
+
+        return $users;
+        
+
+    } // end get_course_users()
+
+
+} // end FundaWande_Coaching_Utils

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
@@ -18,16 +18,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FundaWande_Coaching_Utils {
 
 
-
     /**
      * Constructor
      */
     public function __construct() {
 
-
     }
 
-    
 
     /**
      * Get the course users and coaches.
@@ -38,6 +35,7 @@ class FundaWande_Coaching_Utils {
      */
     public function get_course_users($course_id) {
 
+        // Set up array of course users
         $user_args = array(
             'meta_query' => array(
                 array(
@@ -48,12 +46,15 @@ class FundaWande_Coaching_Utils {
             )
         );
 
+        // Get array of ueser
         $users = get_users( $user_args );
-        
+      
+        // loop through users and assign their coach to object
         foreach ($users as $key => $user) {
             $user->coach = get_user_meta($user->ID,'fw_coach',true);
         }
 
+        // return the users
         return $users;
         
 
@@ -62,22 +63,63 @@ class FundaWande_Coaching_Utils {
     /**
      * Get the coaches.
      *
-     *
      * @return array array of users in the course
      */
     public function get_coaches() {
-
-        $user_args = array(
-            
+        // set up coach args
+        $coach_args = array(
+            'meta_query' => array(
+                array(
+                    'key' => 'is_coach',
+                    'value' => true,
+                    'compare' => '=='
+                ),
+            )
         );
-
-        $users = get_users( $user_args );
+        // get array of coaches
+        $coaches = get_users( $coach_args );
         
-
-        return $users;
+        // return array of coaches
+        return $coaches;
         
 
     } // end get_course_users()
+    
+    /**
+     * Set the bulk coach to users
+     *
+     * @param $data Data passed through the form
+     */
+    public function set_bulk_coach($data) {
+
+        // Loop through selected users
+        foreach ($data['user_select'] as $key => $user_id) {
+
+            // Update the user's coach
+            update_user_meta($user_id,'fw_coach',$data['bulk_coach']);
+        }
+        
+        return true;
+        
+    } // end set_bulk_coach()
+
+    /**
+     * Set the coach to a user
+     *
+     * @return array array of users in the course
+     */
+    public function set_coaches($data) {
+
+        // Loop through all users
+        foreach ($data['coaches'] as $key => $coach_id) {
+            // Update the user's coach
+            update_user_meta($key,'fw_coach',$coach_id);
+        }
+
+        return true;
+        
+
+    } // end set_coaches()
 
 
 } // end FundaWande_Coaching_Utils

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching-utils.php
@@ -33,10 +33,12 @@ class FundaWande_Coaching_Utils {
      *
      * @return array array of users in the course
      */
-    public function get_course_users($course_id) {
+    public function get_course_users($course_id,$orderby = 'display_name',$order = 'ASC') {
 
         // Set up array of course users
         $user_args = array(
+            'orderby'      => $orderby,
+	        'order'        => $order,
             'meta_query' => array(
                 array(
                     'key' => 'fw_current_course',

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
@@ -24,8 +24,86 @@ class FundaWande_Coaching {
      */
     public function __construct() {
 
+        add_action( 'admin_menu', array($this,'register_coaching_menu_page' ));
+
+    }
 
 
+	/**
+	 * Register a coaching menu page.
+	 */
+	function register_coaching_menu_page(){
+
+        add_menu_page( 
+			'Coaching management',
+			'Coaching management',
+			'manage_options',
+			'ffw_coaching',
+			array($this,'fw_coaching_menu_page'),
+			'dashicons-chart-pie',
+			50
+		); 
+
+		// add_action('admin_print_scripts-' . $page_hook_suffix, array(LMS()->paths_admin_utils,'paths_admin_scripts'));
+    }
+    
+
+	/**
+	 * Display coaching menu page
+	 */
+	function fw_coaching_menu_page(){ 
+        $courses = FundaWande()->lms->get_courses();
+        
+        $path_id = null;
+		if ( isset( $_GET['course_id'] ) ) {
+			$course_id = (int) $_GET['course_id'];
+            $course = get_post($course_id);
+            
+        }
+        if ( isset( $_POST['bulk_coach']) ) {
+			FundaWande()->coaching_utils->set_bulk_coach($_POST);
+		}  elseif ( isset( $_POST['coaches']) ) {
+			FundaWande()->coaching_utils->set_coaches($_POST);
+		}
+        ?>
+        <div id="path_relationships_wrapper" class="wrap ">
+			<h1 class="wp-heading-inline">Coaching management</h1>
+			
+			<form id="" action=""  method="get">
+				<input type="hidden" name="page" value="<?= isset( $_GET['page'] ) ? $_GET['page'] : '' ?>">
+				<select id="course_id" name="course_id" class="form-control  customSelect searchSelect" >
+					<option value="all" selected disabled>Choose a course</option>
+					<?php foreach ($courses as $course) { ?>
+						<option value="<?php echo (int) $course->ID; ?>" 
+						<?php if ($course->ID == $course_id) {
+							echo 'selected';
+						} ?>
+						><?php echo $course->ID .' | '.$course->post_title; ?></option>
+					<?php } ?> 
+				</select>
+				<button type="submit"  class="button button-primary button-large" >Select</button>
+			</form>
+                 
+			<?php if (isset($course_id)) { 
+
+                $wp_list_table = new FundaWande_Coaching_Table();
+                $wp_list_table->prepare_items();
+
+		
+				?>
+				<form id="course-users-container" method="post">
+					<h2>Set user coaches: <?php echo $course->post_title; ?></h2>
+						<div id="course-users"  >				
+                            <?php $wp_list_table->display(); ?>
+                        </div>
+                        <button type="submit"  class="button button-primary button-large" >Update coaches</button>
+
+				</form>
+			<?php } ?> 
+			
+		</div>
+		<?php
+	
     }
 
     /**

--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
@@ -38,7 +38,7 @@ class FundaWande_Coaching {
 			'Coaching management',
 			'Coaching management',
 			'manage_options',
-			'ffw_coaching',
+			'fw_coaching',
 			array($this,'fw_coaching_menu_page'),
 			'dashicons-chart-pie',
 			50
@@ -52,14 +52,17 @@ class FundaWande_Coaching {
 	 * Display coaching menu page
 	 */
 	function fw_coaching_menu_page(){ 
+        // Get the array of courses on the LMS
         $courses = FundaWande()->lms->get_courses();
         
-        $path_id = null;
+        $course_id = null;
+        // Check if course ID is set and get the course
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = (int) $_GET['course_id'];
             $course = get_post($course_id);
             
         }
+        // Check if the coach form was submitted and run the bulk or update actions
         if ( isset( $_POST['bulk_coach']) ) {
 			FundaWande()->coaching_utils->set_bulk_coach($_POST);
 		}  elseif ( isset( $_POST['coaches']) ) {
@@ -73,6 +76,7 @@ class FundaWande_Coaching {
 				<input type="hidden" name="page" value="<?= isset( $_GET['page'] ) ? $_GET['page'] : '' ?>">
 				<select id="course_id" name="course_id" class="form-control  customSelect searchSelect" >
 					<option value="all" selected disabled>Choose a course</option>
+                    <!--  loop through courses to set up select options -->
 					<?php foreach ($courses as $course) { ?>
 						<option value="<?php echo (int) $course->ID; ?>" 
 						<?php if ($course->ID == $course_id) {
@@ -85,15 +89,14 @@ class FundaWande_Coaching {
 			</form>
                  
 			<?php if (isset($course_id)) { 
-
+                // Set up the user's coach table 
                 $wp_list_table = new FundaWande_Coaching_Table();
                 $wp_list_table->prepare_items();
-
-		
 				?>
 				<form id="course-users-container" method="post">
 					<h2>Set user coaches: <?php echo $course->post_title; ?></h2>
 						<div id="course-users"  >				
+                            <!-- Display the table -->
                             <?php $wp_list_table->display(); ?>
                         </div>
                         <button type="submit"  class="button button-primary button-large" >Update coaches</button>

--- a/wp-content/plugins/fundawande/includes/class-fundawande-language.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-language.php
@@ -92,9 +92,6 @@ class FundaWande_Language {
                 // Set the user's current course off the lang
                 $current_course_id = get_field('fw_'.$lang.'_course','options',true);
                 update_user_meta($user_id, 'fw_current_course', $current_course_id );
-            } elseif (isset($_GET['course_id'])) {
-                $current_course_id = $_GET['course_id'];
-                update_user_meta($user_id, 'fw_current_course', $current_course_id );
             } elseif (empty($current_course_id)) {
                 // $current_course_id = get_field('fw_xho_course','options',true);
                 // Default to eng for pilot

--- a/wp-content/plugins/fundawande/includes/class-fundawande-lms.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-lms.php
@@ -516,6 +516,21 @@ class FundaWande_Lms {
          return $media_url;
      }
 
+     /**
+     * Fires after an activity is reset to update the progress
+     *
+     **/
+    public function get_courses() {
+        $course_args = array(
+            'post_type' => 'course',
+            'numberposts' => 99,
+        );
+
+        $courses = get_posts($course_args);
+
+        return $courses;
+    }
+
 
     /**
      * Fires after an activity is reset to update the progress

--- a/wp-content/plugins/fundawande/includes/class-fundawande.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande.php
@@ -198,7 +198,10 @@ class FundaWande_Main {
         if ( is_admin() ) {
 
             // Set up admin specific classes
-            $this->admin = new FundaWande_Admin();
+			$this->admin = new FundaWande_Admin();
+			
+			// Setup coaching functionality class
+			$this->coaching_utils = new FundaWande_Coaching_Utils();
 
         } else {
 

--- a/wp-content/themes/fundawande/sensei/single-course.php
+++ b/wp-content/themes/fundawande/sensei/single-course.php
@@ -12,7 +12,10 @@
 if (!is_user_logged_in()) {
     wp_redirect(get_site_url(null, '/login'));
     exit();
-}
+} elseif (isset($_GET['course_id'])) {
+    $current_course_id = $_GET['course_id'];
+    update_user_meta($user_id, 'fw_current_course', $current_course_id );
+} 
 
 if (class_exists('Timber')) {
 

--- a/wp-content/themes/fundawande/templates/lms/template-coach-dash.twig
+++ b/wp-content/themes/fundawande/templates/lms/template-coach-dash.twig
@@ -73,7 +73,7 @@
                                 <th>Submission date</th>
                                 <th>Feedback</th>
                                 <th>Status</th>
-                                <th>Response status</th>
+                                <th>Grading type</th>
                                 <th>Review</th>
 
                             </tr>
@@ -89,9 +89,14 @@
                                         <td>{{ assessment.date|date('d M Y') }}</td>
                                         <td class="feedback-indicator">{% if assessment.needs_feedback %}
                                                 {% if assessment.feedback %}Yes{% else %}No{% endif %}
-                                            {% else %}MCQ{% endif %}</td>
+                                            {% else %}Auto{% endif %}</td>
                                         <td>{% if assessment.status == 'graded' %}Complete{% else %}Submitted{% endif %}</td>
-                                        <td>{% if assessment.response_status %}{{assessment.response_status}}{% else %}-{% endif %}</td>
+                                        <td>{% if assessment.needs_feedback %}
+                                                Manually graded
+                                            {% else %}
+                                                Auto-graded
+                                            {% endif %}
+                                        </td>
                                         <td><a class="review-assessment" {% if assessment.needs_feedback %}href="/review-assessment?assessment_id={{ assessment.lesson_id }}&user_id={{ key }}"{% else %}href="/wp-admin/admin.php?page=sensei_grading&user={{key}}&quiz_id={{ assessment.quiz_id}}"{% endif %}  target="_blank">Review</a></td>
                                     </tr>
                                 {% endfor %}


### PR DESCRIPTION
I created a custom admin page to house the coach management table. The pie icon is random and can be changed easily, not a priority atm. On the page the admin first needs to select a course to manage.

![screenshot 2019-01-24 at 18 53 44](https://user-images.githubusercontent.com/1436311/51694518-a9f96880-2009-11e9-9ac8-c0359d49d0f0.png)

Once a course is selected the course users will be fetched and shown in a custom table. The table allows for the individual assignment of coaches, or a single coach can be assigned in bulk to many users.

![screenshot 2019-01-24 at 18 53 54](https://user-images.githubusercontent.com/1436311/51694519-aa91ff00-2009-11e9-8747-d348eb77c746.png)

The coaches are determined by a new user field 'is_coach' which can either be assigned on the user page or we can do an import via WP ALL Import

![screenshot 2019-01-24 at 18 54 08](https://user-images.githubusercontent.com/1436311/51694520-aa91ff00-2009-11e9-9b83-64f6d52c8f53.png)
